### PR TITLE
Replace ALPINE for UBI image

### DIFF
--- a/build/Dockerfile.controller
+++ b/build/Dockerfile.controller
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG GOLANG_VERSION
-ARG ALPINE_VERSION
+ARG GOLANG_VERSION=1.23.0
 
 FROM golang:$GOLANG_VERSION AS builder
 LABEL stage=builder
@@ -22,7 +21,7 @@ COPY . /go/src/github.com/senthilrch/kube-fledged
 WORKDIR /go/src/github.com/senthilrch/kube-fledged
 RUN CGO_ENABLED=0 go build -o build/kubefledged-controller -ldflags '-s -w -extldflags "-static"' cmd/controller/main.go
 
-FROM alpine:$ALPINE_VERSION
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 LABEL maintainer="senthilrch <senthilrch@gmail.com>"
 COPY --from=builder /go/src/github.com/senthilrch/kube-fledged/build/kubefledged-controller /opt/bin/kubefledged-controller
 RUN chmod 755 /opt/bin/kubefledged-controller

--- a/build/Dockerfile.controller
+++ b/build/Dockerfile.controller
@@ -22,7 +22,6 @@ WORKDIR /go/src/github.com/senthilrch/kube-fledged
 RUN CGO_ENABLED=0 go build -o build/kubefledged-controller -ldflags '-s -w -extldflags "-static"' cmd/controller/main.go
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
-LABEL maintainer="senthilrch <senthilrch@gmail.com>"
 COPY --from=builder /go/src/github.com/senthilrch/kube-fledged/build/kubefledged-controller /opt/bin/kubefledged-controller
 RUN chmod 755 /opt/bin/kubefledged-controller
 ENTRYPOINT ["/opt/bin/kubefledged-controller"]

--- a/build/Dockerfile.controller_dev
+++ b/build/Dockerfile.controller_dev
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG ALPINE_VERSION
 
-FROM alpine:$ALPINE_VERSION
-LABEL maintainer="senthilrch <senthilrch@gmail.com>"
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 COPY build/kubefledged-controller /opt/bin/kubefledged-controller
 RUN chmod 755 /opt/bin/kubefledged-controller

--- a/build/Dockerfile.cri_client
+++ b/build/Dockerfile.cri_client
@@ -12,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG ALPINE_VERSION
-FROM alpine:$ALPINE_VERSION
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
-RUN apk update && apk add --no-cache bash curl openssh-client
+RUN yum update -y && yum install -y bash curl openssh-clients
 
 ARG DOCKER_VERSION
 ARG CRICTL_VERSION

--- a/build/Dockerfile.webhook_server
+++ b/build/Dockerfile.webhook_server
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG GOLANG_VERSION
-ARG ALPINE_VERSION
+ARG GOLANG_VERSION=1.23.0
 
 FROM golang:$GOLANG_VERSION AS builder
 LABEL stage=builder
@@ -22,8 +21,7 @@ COPY . /go/src/github.com/senthilrch/kube-fledged
 WORKDIR /go/src/github.com/senthilrch/kube-fledged
 RUN CGO_ENABLED=0 go build -o build/kubefledged-webhook-server -ldflags '-s -w -extldflags "-static"' cmd/webhook-server/main.go
 
-FROM alpine:$ALPINE_VERSION
-LABEL maintainer="senthilrch <senthilrch@gmail.com>"
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 COPY --from=builder /go/src/github.com/senthilrch/kube-fledged/build/kubefledged-webhook-server /opt/bin/kubefledged-webhook-server
 RUN chmod 755 /opt/bin/kubefledged-webhook-server
 ENTRYPOINT ["/opt/bin/kubefledged-webhook-server"]

--- a/build/Dockerfile.webhook_server_dev
+++ b/build/Dockerfile.webhook_server_dev
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG ALPINE_VERSION
-
-FROM alpine:$ALPINE_VERSION
-LABEL maintainer="senthilrch <senthilrch@gmail.com>"
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 COPY build/kubefledged-webhook-server /opt/bin/kubefledged-webhook-server
 RUN chmod 755 /opt/bin/kubefledged-webhook-server


### PR DESCRIPTION
I created an image with an UBI image (I chose minial instead of micro to include packages like yum) and with the upgraded version of go:

<img width="849" alt="Screenshot 2025-06-20 at 11 14 23 AM" src="https://github.com/user-attachments/assets/ac878977-cd41-471e-a651-77d2f6bc7ffd" />

This image was pushed to a testing ECR repo to validate functionality in staging.

```
>  aws ecr list-images --repository-name kubefledged-test --profile common --output json
{
    "imageIds": [
        {
            "imageDigest": "sha256:08aaf3b6ae281f31bd517dec268d4a2bc8f60403164866cba7036067bd2414ed",
            "imageTag": "v0.11.0"
        },
        {
            "imageDigest": "sha256:08aaf3b6ae281f31bd517dec268d4a2bc8f60403164866cba7036067bd2414ed",
            "imageTag": "v0.10.0"
        }
    ]
}

```

And the upgraded [version worked in staging](https://argocd.eks.hopskipinternal.com/applications/kube-fledged-staging?resource=&node=apps%2FDeployment%2Fkube-fledged%2Fkube-fledged-controller%2F0)

This is in reference to ticket  hopskipdrive/issues#27045